### PR TITLE
Adding file_upload_enforcement support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ resource "azurerm_web_application_firewall_policy" "this" {
       file_upload_limit_in_mb                   = policy_settings.value.file_upload_limit_in_mb
       js_challenge_cookie_expiration_in_minutes = policy_settings.value.js_challenge_cookie_expiration_in_minutes
       max_request_body_size_in_kb               = policy_settings.value.max_request_body_size_in_kb
+      file_upload_enforcement                   = policy_settings.value.file_upload_enforcement
       mode                                      = policy_settings.value.mode
       request_body_check                        = policy_settings.value.request_body_check
       request_body_enforcement                  = policy_settings.value.request_body_enforcement

--- a/variables.tf
+++ b/variables.tf
@@ -169,6 +169,7 @@ variable "policy_settings" {
     file_upload_limit_in_mb                   = optional(number)
     js_challenge_cookie_expiration_in_minutes = optional(number)
     max_request_body_size_in_kb               = optional(number)
+    file_upload_enforcement                   = optional(bool)
     mode                                      = optional(string)
     request_body_check                        = optional(bool)
     request_body_enforcement                  = optional(bool)
@@ -189,6 +190,7 @@ variable "policy_settings" {
  - `file_upload_limit_in_mb` - (Optional) The File Upload Limit in MB. Accepted values are in the range `1` to `4000`. Defaults to `100`.
  - `js_challenge_cookie_expiration_in_minutes` - (Optional) Specifies the JavaScript challenge cookie validity lifetime in minutes. The user is challenged after the lifetime expires. Accepted values are in the range `5` to `1440`. Defaults to `30`.
  - `max_request_body_size_in_kb` - (Optional) The Maximum Request Body Size in KB. Accepted values are in the range `8` to `2000`. Defaults to `128`.
+ - `file_upload_enforcement` - (Optional) Whether the firewall should block a request with file upload size greater than `file_upload_limit_in_mb`. Defaults to `false`.
  - `mode` - (Optional) Describes if it is in detection mode or prevention mode at the policy level. Valid values are `Detection` and `Prevention`. Defaults to `Prevention`.
  - `request_body_check` - (Optional) Is Request Body Inspection enabled? Defaults to `true`.
  - `request_body_enforcement` - (Optional) Whether the firewall should block a request with body size greater then `max_request_body_size_in_kb`. Defaults to `true`.


### PR DESCRIPTION
## Description

Adding support for `file_upload_enforcement` so able to select "Enforce Maximum File Upload Limit" on the resource.
Fixes #24 

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
